### PR TITLE
Remove unused method

### DIFF
--- a/MarkerMetro.Unity.WinLegacyUnity/System/IO/FileInfo.cs
+++ b/MarkerMetro.Unity.WinLegacyUnity/System/IO/FileInfo.cs
@@ -126,11 +126,6 @@ namespace MarkerMetro.Unity.WinLegacy.IO
 
 #if NETFX_CORE
 
-        private async Task<StorageFolder> GetParentAsync(StorageFile file)
-        {
-            return await file.GetParentAsync();
-        }
-
         private async Task<StorageFile> GetFileAsync(string path)
         {
             bool fileExists = File.Exists(path);


### PR DESCRIPTION
Remove GetParentAsync since it is no longer used in the project, also removes the build error when targeting Universal 8.1 in Unity.
