### PR TITLE
ifdef tidy up and spacing between methods

### DIFF
--- a/MarkerMetro.Unity.WinLegacyUnity/System/Security/Cryptography/EncryptionProvider.cs
+++ b/MarkerMetro.Unity.WinLegacyUnity/System/Security/Cryptography/EncryptionProvider.cs
@@ -71,6 +71,10 @@ namespace MarkerMetro.Unity.WinLegacy.Security.Cryptography
             throw new System.PlatformNotSupportedException();
 #endif
         }
+
+
+#if NETFX_CORE
+
         /// <summary>
         /// Hashes given string using specified algorithm.
         /// </summary>
@@ -80,7 +84,6 @@ namespace MarkerMetro.Unity.WinLegacy.Security.Cryptography
         /// <returns></returns>
         private static byte[] Hash(string toHash, HashFunctionType type = HashFunctionType.MD5, byte[] hashKey = null)
         {
-#if NETFX_CORE
             byte[] keyByteArray = System.Text.Encoding.UTF8.GetBytes(toHash);
             switch (type)
             {
@@ -98,11 +101,8 @@ namespace MarkerMetro.Unity.WinLegacy.Security.Cryptography
                     System.Diagnostics.Debug.WriteLine("Unrecognized Hash function type: " + type);
                     throw new ArgumentException("Unrecognized Hash function type: " + type);
             }
-#else
-            throw new System.PlatformNotSupportedException();
-#endif
         }
-
+#endif
 
         /// <summary>
         /// Decrypt a string using dual encryption method. Return a Decrypted clear string

--- a/MarkerMetro.Unity.WinLegacyUnity/System/Security/Cryptography/HmacSHA256.cs
+++ b/MarkerMetro.Unity.WinLegacyUnity/System/Security/Cryptography/HmacSHA256.cs
@@ -15,12 +15,11 @@ namespace MarkerMetro.Unity.WinLegacy.Security.Cryptography
     {
         public void Dispose() { }
 
-
 #if NETFX_CORE
         private MacAlgorithmProvider hmacSha256;
-
         private byte[] KeyValue;
 #endif
+
         public byte[] Key
         {
 #if NETFX_CORE
@@ -37,6 +36,7 @@ namespace MarkerMetro.Unity.WinLegacy.Security.Cryptography
             }
 #endif
         }
+
         public HMACSHA256(byte[] keyValue)
         {
 #if NETFX_CORE
@@ -60,6 +60,7 @@ namespace MarkerMetro.Unity.WinLegacy.Security.Cryptography
             throw new System.PlatformNotSupportedException();
 #endif
         }
+
         /// <summary>
         /// takes in a UTF8 byte array, returns hashed byte array using HmacSHA256
         /// </summary>
@@ -81,5 +82,6 @@ namespace MarkerMetro.Unity.WinLegacy.Security.Cryptography
             throw new System.NotImplementedException();
 #endif
         }
+
     }
 }

--- a/MarkerMetro.Unity.WinLegacyUnity/System/Security/Cryptography/MD5.cs
+++ b/MarkerMetro.Unity.WinLegacyUnity/System/Security/Cryptography/MD5.cs
@@ -25,9 +25,11 @@ namespace MarkerMetro.Unity.WinLegacy.Security.Cryptography
         {
             return new MD5();
         }
+
 #if NETFX_CORE
         private HashAlgorithmProvider hap;
 #endif
+
         protected MD5()
         {
 #if NETFX_CORE

--- a/MarkerMetro.Unity.WinLegacyUnity/System/Security/Cryptography/SHA1.cs
+++ b/MarkerMetro.Unity.WinLegacyUnity/System/Security/Cryptography/SHA1.cs
@@ -23,15 +23,12 @@ namespace MarkerMetro.Unity.WinLegacy.Security.Cryptography
      
 #if NETFX_CORE
         private HashAlgorithmProvider hap;
-#endif
 
         private SHA1()
         {
-#if NETFX_CORE
             hap = HashAlgorithmProvider.OpenAlgorithm(HashAlgorithmNames.Sha1);
-#endif
-
         }
+#endif
 
         public byte[] ComputeHash(byte[] buffer)
         {


### PR DESCRIPTION
for ruslan... note we can ifdef private vars and methods completely, not just implementation. Only public api needs to have the internal ifdef with not supported thrown when not NETFX_CORE. Lastly, just added some spacing between methods (1 line top and bottom) and also reduced spacing between class level member variable declarations (can appear stacked without spacing). 